### PR TITLE
standardizes functions into expected structure for split stacks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@argodigital/serverless-offline",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
**Problem**: Arose with the introduction of the `serverless-plugin-split-stacks`package. When starting the server and trying to register the routes the server functions were coming back as an array rather than an expected object of functions. 

**Solution**: This PR simply checks if the server functions are an array, and if so transforms it into the expected object of functions and runs as before to register the routes. 
